### PR TITLE
feat(renderer): add study dropzone

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "build:electron:test": "yarn workspace jan build:test",
     "build:extensions": "rimraf ./pre-install/*.tgz || true && yarn workspace @janhq/core build && cd extensions && yarn install && yarn workspaces foreach -Apt run build:publish",
     "build:test": "yarn copy:assets && yarn workspace @janhq/web build && cpx \"web/out/**\" \"electron/renderer/\" && yarn workspace jan build:test",
+    "prebuild": "yarn build:joi && yarn build:core && yarn build:server",
     "build": "yarn build:web && yarn build:electron",
     "build:publish": "yarn copy:assets && yarn build:web && yarn workspace jan build:publish",
     "dev:joi": "yarn workspace @janhq/joi install && yarn workspace @janhq/joi dev",

--- a/web/containers/Layout/index.tsx
+++ b/web/containers/Layout/index.tsx
@@ -10,8 +10,8 @@ import { twMerge } from 'tailwind-merge'
 
 import BottomPanel from '@/containers/Layout/BottomPanel'
 import RibbonPanel from '@/containers/Layout/RibbonPanel'
-
 import TopPanel from '@/containers/Layout/TopPanel'
+import StudyDropzone from '@/containers/StudyDropzone'
 
 import { MainViewState } from '@/constants/screens'
 
@@ -239,6 +239,7 @@ const BaseLayout = () => {
           </div>
         )}
       </div>
+      <StudyDropzone categoryId="default" />
       <BottomPanel />
       <ModalAppUpdaterChangelog />
       <ModalAppUpdaterNotAvailable />

--- a/web/containers/StudyDropzone/index.tsx
+++ b/web/containers/StudyDropzone/index.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react'
+
+import { useDropzone } from 'react-dropzone'
+
+import { PlusIcon } from 'lucide-react'
+import { twMerge } from 'tailwind-merge'
+
+export type StudyDropzoneProps = {
+  categoryId: string
+  color?: string
+}
+
+const StudyDropzone = ({
+  categoryId,
+  color = 'hsla(var(--primary-bg))',
+}: StudyDropzoneProps) => {
+  const zoneRef = useRef<HTMLDivElement | null>(null)
+  const { getRootProps, getInputProps, open, isDragActive } = useDropzone({
+    noClick: true,
+    multiple: false,
+    onDrop: (files) => {
+      const file = files[0]
+      if (file) {
+        const withPath = file as unknown as { path?: string }
+        window.electronAPI?.IMPORT_FILE?.({
+          filePath: withPath.path || '',
+          categoryId,
+        })
+      }
+    },
+  })
+
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'i') {
+        e.preventDefault()
+        zoneRef.current?.focus()
+        open()
+      }
+    }
+    window.addEventListener('keydown', handler)
+    return () => window.removeEventListener('keydown', handler)
+  }, [open])
+
+  return (
+    <div
+      {...getRootProps({
+        tabIndex: 0,
+        ref: zoneRef,
+        className: twMerge(
+          'fixed bottom-8 right-8 z-50 flex h-16 w-16 items-center justify-center rounded-full bg-[hsla(var(--app-bg))] text-[hsla(var(--text-primary))] focus:outline-none',
+          isDragActive && 'shadow-[0_0_0_4px_var(--category-color)]'
+        ),
+        style: isDragActive ? { boxShadow: `0 0 0 4px ${color}` } : undefined,
+      })}
+    >
+      <input {...getInputProps()} />
+      {isDragActive ? (
+        <span className="text-xs font-semibold">Drop to Study</span>
+      ) : (
+        <PlusIcon size={24} />
+      )}
+    </div>
+  )
+}
+
+export default StudyDropzone


### PR DESCRIPTION
## Summary
- add floating StudyDropzone
- mount StudyDropzone in layout
- run package builds before main build to fix missing modules

## Testing
- `yarn lint`
- `yarn build`
- `yarn test` *(fails: hub.e2e.spec.ts fails)*

------
https://chatgpt.com/codex/tasks/task_e_6848437f7be883258b74bf16188b6089