### PR TITLE
fix: ignore cert errors in e2e

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -31,6 +31,14 @@ import { registerGlobalShortcuts } from './utils/shortcut'
 import { registerLogger } from './utils/logger'
 import { randomBytes } from 'crypto'
 
+// When running in e2e mode the container environment proxies HTTPS
+// requests which breaks certificate validation in Chromium.
+// Disable GPU and ignore certificate errors to keep Electron stable.
+if (process.env.CI === 'e2e') {
+  app.commandLine.appendSwitch('ignore-certificate-errors')
+  app.disableHardwareAcceleration()
+}
+
 const preloadPath = join(__dirname, 'preload.js')
 const preloadQuickAskPath = join(__dirname, 'preload.quickask.js')
 const rendererPath = join(__dirname, '..', 'renderer')


### PR DESCRIPTION
## Summary
- disable GPU and ignore cert errors when running e2e

## Testing
- `yarn lint`
- `yarn build` *(fails: Can't resolve `@janhq/joi`)*
- `yarn test` *(fails: `xvfb-run` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ae9e45a8483259dac5ff3431ec552